### PR TITLE
Add check if import dicom works if not try import pydicom

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # j-pet-format-converter
-## version 1.2
+## version 1.3
 ### Author: Rafał Masełek
 ### Email: rafal.maselek@ncbj.gov.pl
+### Modifications: Wojciech Krzemien 
 
 This script enables converting raw 3D binary images to DICOM file format and importing meta-data from external file.
 

--- a/binary2DICOM.py
+++ b/binary2DICOM.py
@@ -7,10 +7,9 @@
 
 import sys
 try:
-  from dicom.dataset import Dataset, FileDataset
-except ImportError:
-  print("import dicom failed, trying import pydicom") 
   from pydicom.dataset import Dataset, FileDataset
+except ImportError:
+  from dicom.dataset import Dataset, FileDataset
 
 import datetime
 import time

--- a/binary2DICOM.py
+++ b/binary2DICOM.py
@@ -6,11 +6,17 @@
 # This script enables converting raw 3D binary images to DICOM file format and importing meta-data from external file.
 
 import sys
-from dicom.dataset import Dataset, FileDataset
-import numpy as np
-import datetime, time
+try:
+  from dicom.dataset import Dataset, FileDataset
+except ImportError:
+  print("import dicom failed, trying import pydicom") 
+  from pydicom.dataset import Dataset, FileDataset
+
+import datetime
+import time
 import argparse
-binary2DICOM_version = "version 1.2 features included:\n\t1)Reading raw binary file with image\n\t2)Reading file with meta-data\n\t3)Creating\
+import numpy as np
+binary2DICOM_version = "version 1.3 features included:\n\t1)Reading raw binary file with image\n\t2)Reading file with meta-data\n\t3)Creating\
  a new DICOM file\n\t4)Reading image parameters from meta-data\n\t5)Smart argument parser\n\t6)Using converter as a module"
 
 


### PR DESCRIPTION
The new pydicom library version breaks compatibility, and the
import name changes. To avoid the problem two version are tried to
be imported.